### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -8,13 +8,13 @@ class syntax_plugin_nssize extends DokuWiki_Syntax_Plugin {
   function connectTo($mode) { $this->Lexer->addSpecialPattern('\{\{nssize>[^}]*\}\}',$mode,'plugin_nssize'); }
 
     // Handling lexer
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match,8,-2);
         if($match[0]=='>') $match = substr($match,1);
         return array($state,$match);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $conf;
         if($mode!='xhtml') return false;
         $paths = array('datadir'   => 'pages',


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.